### PR TITLE
Improved errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -20,20 +20,16 @@ type Error struct {
 }
 
 func (code ErrorCode) String() string {
-	var msg string
-
 	switch code {
 	case ErrUnknown:
-		msg = "unknown"
+		return "unknown"
 	case ErrMinerConnectionFailed:
-		msg = "miner connection failed"
+		return "miner connection failed"
 	case ErrLotusError:
-		msg = "lotus error"
+		return "lotus error"
 	default:
-		msg = "(invalid error code)"
+		return "(invalid error code)"
 	}
-
-	return msg
 }
 
 func (err *Error) Error() string {

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,54 @@
+package filclient
+
+import "fmt"
+
+const (
+	// Failed to connect to a miner.
+	ErrMinerConnectionFailed = iota
+
+	// There was an issue related to the Lotus API.
+	ErrLotusError
+)
+
+type Error struct {
+	Code  int
+	Inner error
+}
+
+func ErrorString(code int) string {
+	var msg string
+
+	switch code {
+	case ErrMinerConnectionFailed:
+		msg = "miner connection failed"
+	case ErrLotusError:
+		msg = "lotus error"
+	default:
+		msg = "(invalid error code)"
+	}
+
+	return msg
+}
+
+func (err *Error) Error() string {
+	return fmt.Sprintf("%v: %v", ErrorString(err.Code), err.Inner.Error())
+}
+
+func (err *Error) Unwrap() error {
+	return err.Inner
+}
+
+func NewError(code int, err error) *Error {
+	return &Error{
+		Code:  code,
+		Inner: err,
+	}
+}
+
+func NewErrMinerConnectionFailed(err error) error {
+	return NewError(ErrMinerConnectionFailed, err)
+}
+
+func NewErrLotusError(err error) error {
+	return NewError(ErrLotusError, err)
+}

--- a/errors.go
+++ b/errors.go
@@ -5,8 +5,10 @@ import "fmt"
 type ErrorCode int
 
 const (
+	ErrUnknown ErrorCode = iota
+
 	// Failed to connect to a miner.
-	ErrMinerConnectionFailed ErrorCode = iota
+	ErrMinerConnectionFailed
 
 	// There was an issue related to the Lotus API.
 	ErrLotusError
@@ -21,6 +23,8 @@ func (code ErrorCode) String() string {
 	var msg string
 
 	switch code {
+	case ErrUnknown:
+		msg = "unknown"
 	case ErrMinerConnectionFailed:
 		msg = "miner connection failed"
 	case ErrLotusError:
@@ -45,6 +49,10 @@ func NewError(code ErrorCode, err error) *Error {
 		Code:  code,
 		Inner: err,
 	}
+}
+
+func NewErrUnknown(err error) error {
+	return NewError(ErrUnknown, err)
 }
 
 func NewErrMinerConnectionFailed(err error) error {

--- a/errors.go
+++ b/errors.go
@@ -2,20 +2,22 @@ package filclient
 
 import "fmt"
 
+type ErrorCode int
+
 const (
 	// Failed to connect to a miner.
-	ErrMinerConnectionFailed = iota
+	ErrMinerConnectionFailed ErrorCode = iota
 
 	// There was an issue related to the Lotus API.
 	ErrLotusError
 )
 
 type Error struct {
-	Code  int
+	Code  ErrorCode
 	Inner error
 }
 
-func ErrorString(code int) string {
+func (code ErrorCode) String() string {
 	var msg string
 
 	switch code {
@@ -31,14 +33,14 @@ func ErrorString(code int) string {
 }
 
 func (err *Error) Error() string {
-	return fmt.Sprintf("%v: %v", ErrorString(err.Code), err.Inner.Error())
+	return fmt.Sprintf("%v: %v", err.Code.String(), err.Inner.Error())
 }
 
 func (err *Error) Unwrap() error {
 	return err.Inner
 }
 
-func NewError(code int, err error) *Error {
+func NewError(code ErrorCode, err error) *Error {
 	return &Error{
 		Code:  code,
 		Inner: err,

--- a/errors.go
+++ b/errors.go
@@ -33,7 +33,7 @@ func (code ErrorCode) String() string {
 }
 
 func (err *Error) Error() string {
-	return fmt.Sprintf("%v: %v", err.Code.String(), err.Inner.Error())
+	return fmt.Sprintf("%s: %s", err.Code, err.Inner)
 }
 
 func (err *Error) Unwrap() error {

--- a/filclient.go
+++ b/filclient.go
@@ -223,18 +223,18 @@ func (fc *FilClient) streamToMiner(ctx context.Context, maddr address.Address, p
 func (fc *FilClient) connectToMiner(ctx context.Context, maddr address.Address) (peer.ID, error) {
 	minfo, err := fc.api.StateMinerInfo(ctx, maddr, types.EmptyTSK)
 	if err != nil {
-		return "", NewErrLotusError(err)
+		return "", NewErrMinerConnectionFailed(NewErrLotusError(err))
 	}
 
 	if minfo.PeerId == nil {
-		return "", fmt.Errorf("miner %s has no peer ID set", maddr)
+		return "", NewErrMinerConnectionFailed(fmt.Errorf("miner %s has no peer ID set", maddr))
 	}
 
 	var maddrs []multiaddr.Multiaddr
 	for _, mma := range minfo.Multiaddrs {
 		ma, err := multiaddr.NewMultiaddrBytes(mma)
 		if err != nil {
-			return "", fmt.Errorf("miner %s had invalid multiaddrs in their info: %w", maddr, err)
+			return "", NewErrMinerConnectionFailed(fmt.Errorf("miner %s had invalid multiaddrs in their info: %w", maddr, err))
 		}
 		maddrs = append(maddrs, ma)
 	}
@@ -243,7 +243,7 @@ func (fc *FilClient) connectToMiner(ctx context.Context, maddr address.Address) 
 		ID:    *minfo.PeerId,
 		Addrs: maddrs,
 	}); err != nil {
-		return "", err
+		return "", NewErrMinerConnectionFailed(err)
 	}
 
 	return *minfo.PeerId, nil

--- a/filclient.go
+++ b/filclient.go
@@ -208,7 +208,7 @@ func (fc *FilClient) streamToMiner(ctx context.Context, maddr address.Address, p
 
 	mpid, err := fc.connectToMiner(ctx, maddr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to miner: %s", err)
+		return nil, err
 	}
 
 	s, err := fc.host.NewStream(ctx, mpid, protocol)
@@ -219,22 +219,11 @@ func (fc *FilClient) streamToMiner(ctx context.Context, maddr address.Address, p
 	return s, nil
 }
 
-type ApiError struct {
-	Under error
-}
-
-func (e *ApiError) Error() string {
-	return fmt.Sprintf("api error: %s", e.Under)
-}
-
-func (e *ApiError) Unwrap() error {
-	return e.Under
-}
-
+// Errors - ErrMinerConnectionFailed, ErrLotusError
 func (fc *FilClient) connectToMiner(ctx context.Context, maddr address.Address) (peer.ID, error) {
 	minfo, err := fc.api.StateMinerInfo(ctx, maddr, types.EmptyTSK)
 	if err != nil {
-		return "", &ApiError{err}
+		return "", NewErrLotusError(err)
 	}
 
 	if minfo.PeerId == nil {
@@ -660,7 +649,7 @@ func (fc *FilClient) StartDataTransfer(ctx context.Context, miner address.Addres
 
 	mpid, err := fc.connectToMiner(ctx, miner)
 	if err != nil {
-		return nil, fmt.Errorf("getting miner peer: %w", err)
+		return nil, err
 	}
 
 	voucher := &requestvalidation.StorageDataTransferVoucher{Proposal: propCid}
@@ -783,7 +772,7 @@ func (fc *FilClient) CheckOngoingTransfer(ctx context.Context, miner address.Add
 		// try reconnecting
 		mpid, err := fc.connectToMiner(ctx, miner)
 		if err != nil {
-			return fmt.Errorf("failed to reconnect to miner: %w", err)
+			return err
 		}
 
 		if mpid != st.RemotePeer {


### PR DESCRIPTION
This is mostly a framework for future improvements around Filclient's error generation. `errors.As` with the `filclient.Error` type, followed by checking the error code, can now be used to discover if an error is of a specific category (currently just `ErrMinerConnectionFailed` and `ErrLotusError`). The current set of errors should probably be expanded on over time.

A couple lines will need to be modified in Estuary to accommodate this change.