### PR TITLE
Feat/subselector retrieval

### DIFF
--- a/filc/cmds.go
+++ b/filc/cmds.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"time"
 
@@ -21,6 +22,13 @@ import (
 	"github.com/ipfs/go-merkledag"
 	unixfile "github.com/ipfs/go-unixfs/file"
 	"github.com/ipfs/go-unixfs/importer"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	"github.com/ipld/go-ipld-prime/traversal"
+	"github.com/ipld/go-ipld-prime/traversal/selector"
+	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
+	textselector "github.com/ipld/go-ipld-selector-text-lite"
 	cli "github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
 )
@@ -283,12 +291,15 @@ var retrieveFileCmd = &cli.Command{
 	Flags: []cli.Flag{
 		flagMinersRequired,
 		flagOutput,
+		flagDmPathSel,
 	},
 	Action: func(cctx *cli.Context) error {
 		cidStr := cctx.Args().First()
 		if cidStr == "" {
 			return fmt.Errorf("please specify a CID to retrieve")
 		}
+
+		dmSelText := textselector.Expression(cctx.String(flagDmPathSel.Name))
 
 		miners, err := parseMiners(cctx)
 		if err != nil {
@@ -301,11 +312,35 @@ var retrieveFileCmd = &cli.Command{
 		}
 		if output == "" {
 			output = cidStr
+			if dmSelText != "" {
+				output += "_" + url.QueryEscape(string(dmSelText))
+			}
 		}
 
 		root, err := cid.Decode(cidStr)
 		if err != nil {
 			return err
+		}
+
+		var selNode ipld.Node
+		if dmSelText != "" {
+			ssb := builder.NewSelectorSpecBuilder(basicnode.Prototype.Any)
+
+			selspec, err := textselector.SelectorSpecFromPath(
+				dmSelText,
+
+				// URGH - this is a direct copy from https://github.com/filecoin-project/go-fil-markets/blob/v1.12.0/shared/selectors.go#L10-L16
+				// Unable to use it because we need the SelectorSpec, and markets exposes just a reified node
+				ssb.ExploreRecursive(
+					selector.RecursionLimitNone(),
+					ssb.ExploreAll(ssb.ExploreRecursiveEdge()),
+				),
+			)
+			if err != nil {
+				return xerrors.Errorf("failed to parse text-selector '%s': %w", dmSelText, err)
+			}
+
+			selNode = selspec.Node()
 		}
 
 		ddir := ddir(cctx)
@@ -325,6 +360,9 @@ var retrieveFileCmd = &cli.Command{
 		var retrievalDone bool
 		for _, miner := range miners {
 			msg := fmt.Sprintf("attempting retrieval with miner %s => root %s", miner, root)
+			if dmSelText != "" {
+				msg += " => selector " + string(dmSelText)
+			}
 			fmt.Println(msg)
 
 			ask, err := fc.RetrievalQuery(cctx.Context, miner, root)
@@ -333,7 +371,7 @@ var retrieveFileCmd = &cli.Command{
 				continue
 			}
 
-			proposal, err := retrievehelper.RetrievalProposalForAsk(ask, root, nil)
+			proposal, err := retrievehelper.RetrievalProposalForAsk(ask, root, selNode)
 			if err != nil {
 				fmt.Println(err)
 				continue
@@ -358,6 +396,37 @@ var retrieveFileCmd = &cli.Command{
 		fmt.Println("Saving output to ", output)
 
 		dserv := merkledag.NewDAGService(blockservice.New(node.Blockstore, offline.Exchange(node.Blockstore)))
+
+		// if we used a selector - need to find the sub-root the user actually wanted to retrieve
+		if dmSelText != "" {
+			var subRootFound bool
+
+			// no err check - we just compiled this before starting, but now we do not wrap a `*`
+			selspec, _ := textselector.SelectorSpecFromPath(dmSelText, nil) //nolint:errcheck
+			if err := retrievehelper.TraverseDag(
+				cctx.Context,
+				dserv,
+				root,
+				selspec.Node(),
+				func(p traversal.Progress, n ipld.Node, r traversal.VisitReason) error {
+					if r == traversal.VisitReason_SelectionMatch {
+						cidLnk, castOK := p.LastBlock.Link.(cidlink.Link)
+						if !castOK {
+							return xerrors.Errorf("cidlink cast unexpectedly failed on '%s'", p.LastBlock.Link.String())
+						}
+						root = cidLnk.Cid
+						subRootFound = true
+					}
+					return nil
+				},
+			); err != nil {
+				return xerrors.Errorf("error determining partial retrieval sub-root: %w", err)
+			}
+
+			if !subRootFound {
+				return xerrors.Errorf("path selection '%s' does not match a node within %s", dmSelText, root)
+			}
+		}
 
 		dnode, err := dserv.Get(cctx.Context, root)
 		if err != nil {

--- a/filc/cmds.go
+++ b/filc/cmds.go
@@ -410,17 +410,23 @@ var retrieveFileCmd = &cli.Command{
 				selspec.Node(),
 				func(p traversal.Progress, n ipld.Node, r traversal.VisitReason) error {
 					if r == traversal.VisitReason_SelectionMatch {
+
+						if p.LastBlock.Path.String() != p.Path.String() {
+							return xerrors.Errorf("unsupported selection path '%s' does not correspond to a node boundary (a.k.a. CID link)", p.Path.String())
+						}
+
 						cidLnk, castOK := p.LastBlock.Link.(cidlink.Link)
 						if !castOK {
 							return xerrors.Errorf("cidlink cast unexpectedly failed on '%s'", p.LastBlock.Link.String())
 						}
+
 						root = cidLnk.Cid
 						subRootFound = true
 					}
 					return nil
 				},
 			); err != nil {
-				return xerrors.Errorf("error determining partial retrieval sub-root: %w", err)
+				return xerrors.Errorf("error while locating partial retrieval sub-root: %w", err)
 			}
 
 			if !subRootFound {

--- a/filc/flags.go
+++ b/filc/flags.go
@@ -32,3 +32,8 @@ var flagOutput = &cli.StringFlag{
 	Name:    "output",
 	Aliases: []string{"o"},
 }
+
+var flagDmPathSel = &cli.StringFlag{
+       Name:  "datamodel-path-selector",
+       Usage: "a rudimentary (DM-level-only) text-path selector, allowing for sub-selection within a deal",
+}

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/ipfs/go-unixfs v0.2.6
 	github.com/ipld/go-car v0.3.1-0.20210601190600-f512dac51e8e
 	github.com/ipld/go-codec-dagpb v1.3.0
-	github.com/ipld/go-ipld-prime v0.12.2
+	github.com/ipld/go-ipld-prime v0.12.3
 	github.com/ipld/go-ipld-selector-text-lite v0.0.0-20210817134355-4c190a2bb825
 	github.com/kr/text v0.2.0 // indirect
 	github.com/libp2p/go-libp2p v0.14.2

--- a/go.mod
+++ b/go.mod
@@ -33,11 +33,14 @@ require (
 	github.com/ipfs/go-ipfs-chunker v0.0.5
 	github.com/ipfs/go-ipfs-exchange-offline v0.0.1
 	github.com/ipfs/go-ipfs-files v0.0.8
+	github.com/ipfs/go-ipld-format v0.2.0
 	github.com/ipfs/go-log v1.0.5
 	github.com/ipfs/go-merkledag v0.4.0
 	github.com/ipfs/go-unixfs v0.2.6
 	github.com/ipld/go-car v0.3.1-0.20210601190600-f512dac51e8e
+	github.com/ipld/go-codec-dagpb v1.3.0
 	github.com/ipld/go-ipld-prime v0.12.2
+	github.com/ipld/go-ipld-selector-text-lite v0.0.0-20210817134355-4c190a2bb825
 	github.com/kr/text v0.2.0 // indirect
 	github.com/libp2p/go-libp2p v0.14.2
 	github.com/libp2p/go-libp2p-core v0.8.6

--- a/go.sum
+++ b/go.sum
@@ -782,6 +782,7 @@ github.com/ipld/go-ipld-prime v0.5.1-0.20200828233916-988837377a7f/go.mod h1:0xE
 github.com/ipld/go-ipld-prime v0.5.1-0.20201021195245-109253e8a018/go.mod h1:0xEgdD6MKbZ1vF0GC+YcR/C4SQCAlRuOjIJ2i0HxqzM=
 github.com/ipld/go-ipld-prime v0.9.0/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
 github.com/ipld/go-ipld-prime v0.9.1-0.20210324083106-dc342a9917db/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
+github.com/ipld/go-ipld-prime v0.10.0/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
 github.com/ipld/go-ipld-prime v0.11.0/go.mod h1:+WIAkokurHmZ/KwzDOMUuoeJgaRQktHtEaLglS3ZeV8=
 github.com/ipld/go-ipld-prime v0.12.0/go.mod h1:hy8b93WleDMRKumOJnTIrr0MbbFbx9GD6Kzxa53Xppc=
 github.com/ipld/go-ipld-prime v0.12.2 h1:StIquYvKIRuSEAtjJDr39fyzBtziioHPwVC75tBiXzo=
@@ -790,6 +791,8 @@ github.com/ipld/go-ipld-prime-proto v0.0.0-20191113031812-e32bd156a1e5/go.mod h1
 github.com/ipld/go-ipld-prime-proto v0.0.0-20200428191222-c1ffdadc01e1/go.mod h1:OAV6xBmuTLsPZ+epzKkPB1e25FHk/vCtyatkdHcArLs=
 github.com/ipld/go-ipld-prime-proto v0.0.0-20200922192210-9a2bfd4440a6/go.mod h1:3pHYooM9Ea65jewRwrb2u5uHZCNkNTe9ABsVB+SrkH0=
 github.com/ipld/go-ipld-prime-proto v0.1.0/go.mod h1:11zp8f3sHVgIqtb/c9Kr5ZGqpnCLF1IVTNOez9TopzE=
+github.com/ipld/go-ipld-selector-text-lite v0.0.0-20210817134355-4c190a2bb825 h1:sGlmVUuWEhuJpVsErFqCHWy9XTsIy511hZWRWI/Lc4I=
+github.com/ipld/go-ipld-selector-text-lite v0.0.0-20210817134355-4c190a2bb825/go.mod h1:U2CQmFb+uWzfIEF3I1arrDa5rwtj00PrpiwwCO+k1RM=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/jackpal/gateway v1.0.4/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=

--- a/go.sum
+++ b/go.sum
@@ -785,8 +785,8 @@ github.com/ipld/go-ipld-prime v0.9.1-0.20210324083106-dc342a9917db/go.mod h1:KvB
 github.com/ipld/go-ipld-prime v0.10.0/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
 github.com/ipld/go-ipld-prime v0.11.0/go.mod h1:+WIAkokurHmZ/KwzDOMUuoeJgaRQktHtEaLglS3ZeV8=
 github.com/ipld/go-ipld-prime v0.12.0/go.mod h1:hy8b93WleDMRKumOJnTIrr0MbbFbx9GD6Kzxa53Xppc=
-github.com/ipld/go-ipld-prime v0.12.2 h1:StIquYvKIRuSEAtjJDr39fyzBtziioHPwVC75tBiXzo=
-github.com/ipld/go-ipld-prime v0.12.2/go.mod h1:PaeLYq8k6dJLmDUSLrzkEpoGV4PEfe/1OtFN/eALOc8=
+github.com/ipld/go-ipld-prime v0.12.3 h1:furVobw7UBLQZwlEwfE26tYORy3PAK8VYSgZOSr3JMQ=
+github.com/ipld/go-ipld-prime v0.12.3/go.mod h1:PaeLYq8k6dJLmDUSLrzkEpoGV4PEfe/1OtFN/eALOc8=
 github.com/ipld/go-ipld-prime-proto v0.0.0-20191113031812-e32bd156a1e5/go.mod h1:gcvzoEDBjwycpXt3LBE061wT9f46szXGHAmj9uoP6fU=
 github.com/ipld/go-ipld-prime-proto v0.0.0-20200428191222-c1ffdadc01e1/go.mod h1:OAV6xBmuTLsPZ+epzKkPB1e25FHk/vCtyatkdHcArLs=
 github.com/ipld/go-ipld-prime-proto v0.0.0-20200922192210-9a2bfd4440a6/go.mod h1:3pHYooM9Ea65jewRwrb2u5uHZCNkNTe9ABsVB+SrkH0=

--- a/retrievehelper/selector.go
+++ b/retrievehelper/selector.go
@@ -28,15 +28,13 @@ func TraverseDag(
 	visitCallback traversal.AdvVisitFn,
 ) error {
 
-	var parsedSelector selector.Selector
 	if optionalSelector == nil {
-		parsedSelector = selectorparse.CommonSelector_MatchAllRecursively
-	} else {
-		var err error
-		parsedSelector, err = selector.ParseSelector(optionalSelector)
-		if err != nil {
-			return err
-		}
+		optionalSelector = selectorparse.CommonSelector_MatchAllRecursively
+	}
+
+	parsedSelector, err := selector.ParseSelector(optionalSelector)
+	if err != nil {
+		return err
 	}
 
 	// not sure what this is for TBH: we also provide ctx in  &traversal.Config{}

--- a/retrievehelper/selector.go
+++ b/retrievehelper/selector.go
@@ -1,0 +1,91 @@
+package retrievehelper
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	// must be imported to init() raw-codec support
+	_ "github.com/ipld/go-ipld-prime/codec/raw"
+
+	"github.com/ipfs/go-cid"
+	mdagipld "github.com/ipfs/go-ipld-format"
+	dagpb "github.com/ipld/go-codec-dagpb"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	"github.com/ipld/go-ipld-prime/traversal"
+	"github.com/ipld/go-ipld-prime/traversal/selector"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
+)
+
+func TraverseDag(
+	ctx context.Context,
+	ds mdagipld.DAGService,
+	startFrom cid.Cid,
+	optionalSelector ipld.Node,
+	visitCallback traversal.AdvVisitFn,
+) error {
+
+	var parsedSelector selector.Selector
+	if optionalSelector == nil {
+		parsedSelector = selectorparse.CommonSelector_MatchAllRecursively
+	} else {
+		var err error
+		parsedSelector, err = selector.ParseSelector(optionalSelector)
+		if err != nil {
+			return err
+		}
+	}
+
+	// not sure what this is for TBH: we also provide ctx in  &traversal.Config{}
+	linkContext := ipld.LinkContext{Ctx: ctx}
+
+	// this is what allows us to understand dagpb
+	nodePrototypeChooser := dagpb.AddSupportToChooser(
+		func(ipld.Link, ipld.LinkContext) (ipld.NodePrototype, error) {
+			return basicnode.Prototype.Any, nil
+		},
+	)
+
+	// this is how we implement GETs
+	linkSystem := cidlink.DefaultLinkSystem()
+	linkSystem.StorageReadOpener = func(lctx ipld.LinkContext, lnk ipld.Link) (io.Reader, error) {
+		cl, isCid := lnk.(cidlink.Link)
+		if !isCid {
+			return nil, fmt.Errorf("unexpected link type %#v", lnk)
+		}
+
+		node, err := ds.Get(lctx.Ctx, cl.Cid)
+		if err != nil {
+			return nil, err
+		}
+
+		return bytes.NewBuffer(node.RawData()), nil
+	}
+
+	// this is how we pull the start node out of the DS
+	startLink := cidlink.Link{Cid: startFrom}
+	startNodePrototype, err := nodePrototypeChooser(startLink, linkContext)
+	if err != nil {
+		return err
+	}
+	startNode, err := linkSystem.Load(
+		linkContext,
+		startLink,
+		startNodePrototype,
+	)
+	if err != nil {
+		return err
+	}
+
+	// this is the actual execution, invoking the supplied callback
+	return traversal.Progress{
+		Cfg: &traversal.Config{
+			Ctx:                            ctx,
+			LinkSystem:                     linkSystem,
+			LinkTargetNodePrototypeChooser: nodePrototypeChooser,
+		},
+	}.WalkAdv(startNode, parsedSelector, visitCallback)
+}


### PR DESCRIPTION
This is an amalgam of https://github.com/filecoin-project/lotus/pull/6393 and the abandoned https://github.com/application-research/estuary/pull/5, providing a fully featured selector retrieval to `filc`

Given a random [cid status like this](https://api.nft.storage/check/Qmcs9cs9BXXRWsWzqL3fw4PupgomGr74rfrB6JAFBiPWFp), one should be able to:
```
filc retrieve -m {{chosenminer}} --datamodel-path-selector Links/217/Hash/Links/30/Hash/Links/0/Hash bafybeihco4vemvoyuca7vqomert5fuvf6deksmakftu654mipagdkehzyu