### PR TITLE
Tune graphsync max memory per peer

### DIFF
--- a/filclient.go
+++ b/filclient.go
@@ -116,7 +116,7 @@ func NewClient(h host.Host, api api.Gateway, w *wallet.LocalWallet, addr address
 		storeutil.LinkSystemForBlockstore(bs),
 		graphsync.MaxInProgressRequests(200),
 		graphsync.MaxMemoryResponder(8<<30),
-		graphsync.MaxMemoryPerPeerResponder(256<<20),
+		graphsync.MaxMemoryPerPeerResponder(32<<20),
 	)
 
 	tpt := gst.NewTransport(h.ID(), gse)


### PR DESCRIPTION
# Goals

To avoid graphsync allocator locks, we should follow this basic formula

MaxMemoryResponder >= MaxMemoryPerPeerResponder * MaxInProgressRequests

Essentially we need to make sure the total memory allocated for graphsync is greater or equal to the total memory per peer times the number of simultaneous requests. That way, even when serving the maximum number of simultaneous requests, there's no likelyhood, assuming everything is running properly, that we will max out the allocator.