### PR TITLE
Update for 0.10.3 with better tuning and stats

### DIFF
--- a/filclient.go
+++ b/filclient.go
@@ -37,7 +37,8 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
-	graphsync "github.com/ipfs/go-graphsync/impl"
+	"github.com/ipfs/go-graphsync"
+	gsimpl "github.com/ipfs/go-graphsync/impl"
 	gsnet "github.com/ipfs/go-graphsync/network"
 	storeutil "github.com/ipfs/go-graphsync/storeutil"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
@@ -86,6 +87,8 @@ type FilClient struct {
 	computePieceComm GetPieceCommFunc
 
 	RetrievalProgressLogging bool
+
+	graphSync graphsync.GraphExchange
 }
 
 type GetPieceCommFunc func(ctx context.Context, payloadCid cid.Cid, bstore blockstore.Blockstore) (cid.Cid, abi.UnpaddedPieceSize, error)
@@ -111,13 +114,16 @@ func NewClient(h host.Host, api api.Gateway, w *wallet.LocalWallet, addr address
 		return nil, err
 	}
 
-	gse := graphsync.New(context.Background(),
+	gse := gsimpl.New(context.Background(),
 		gsnet.NewFromLibp2pHost(h),
 		storeutil.LinkSystemForBlockstore(bs),
-		graphsync.MaxInProgressIncomingRequests(200),
-		graphsync.MaxInProgressOutgoingRequests(200),
-		graphsync.MaxMemoryResponder(8<<30),
-		graphsync.MaxMemoryPerPeerResponder(32<<20),
+		gsimpl.MaxInProgressIncomingRequests(200),
+		gsimpl.MaxInProgressOutgoingRequests(200),
+		gsimpl.MaxMemoryResponder(8<<30),
+		gsimpl.MaxMemoryPerPeerResponder(32<<20),
+		gsimpl.MaxInProgressIncomingRequestsPerPeer(20),
+		gsimpl.MessageSendRetries(2),
+		gsimpl.SendMessageTimeout(2*time.Minute),
 	)
 
 	dtn := dtnet.NewFromLibp2pHost(h)
@@ -196,6 +202,7 @@ func NewClient(h host.Host, api api.Gateway, w *wallet.LocalWallet, addr address
 		pchmgr:           pchmgr,
 		mpusher:          mpusher,
 		computePieceComm: GeneratePieceCommitment,
+		graphSync:        gse,
 	}, nil
 }
 
@@ -599,6 +606,10 @@ func ChannelStateConv(st datatransfer.ChannelState) *ChannelState {
 
 func (fc *FilClient) TransfersInProgress(ctx context.Context) (map[datatransfer.ChannelID]datatransfer.ChannelState, error) {
 	return fc.dataTransfer.InProgressChannels(ctx)
+}
+
+func (fc *FilClient) GraphSyncStats() graphsync.Stats {
+	return fc.graphSync.Stats()
 }
 
 func (fc *FilClient) TransferStatus(ctx context.Context, chanid *datatransfer.ChannelID) (*ChannelState, error) {

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/ipfs/go-cid v0.1.0
 	github.com/ipfs/go-datastore v0.4.6
 	github.com/ipfs/go-ds-leveldb v0.4.2
-	github.com/ipfs/go-graphsync v0.10.2
+	github.com/ipfs/go-graphsync v0.10.3
 	github.com/ipfs/go-ipfs-blockstore v1.0.5-0.20210802214209-c56038684c45
 	github.com/ipfs/go-ipfs-chunker v0.0.5
 	github.com/ipfs/go-ipfs-exchange-offline v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -678,6 +678,8 @@ github.com/ipfs/go-graphsync v0.10.0/go.mod h1:cKIshzTaa5rCZjryH5xmSKZVGX9uk1wvw
 github.com/ipfs/go-graphsync v0.10.1/go.mod h1:cKIshzTaa5rCZjryH5xmSKZVGX9uk1wvwGvz2WEha5Y=
 github.com/ipfs/go-graphsync v0.10.2 h1:LFox7892ld9mZ+2ePKewFYwdhN+OIfFm1/FYpHy/WV4=
 github.com/ipfs/go-graphsync v0.10.2/go.mod h1:cKIshzTaa5rCZjryH5xmSKZVGX9uk1wvwGvz2WEha5Y=
+github.com/ipfs/go-graphsync v0.10.3 h1:vBjuUqiFM466oKmz6t5pATr3UsYTSTndlqLOjx7nT9s=
+github.com/ipfs/go-graphsync v0.10.3/go.mod h1:oei4tnWAKnZ6LPnapZGPYVVbyiKV1UP3f8BeLU7Z4JQ=
 github.com/ipfs/go-hamt-ipld v0.1.1/go.mod h1:1EZCr2v0jlCnhpa+aZ0JZYp8Tt2w16+JJOAVz17YcDk=
 github.com/ipfs/go-ipfs-blockstore v0.0.1/go.mod h1:d3WClOmRQKFnJ0Jz/jj/zmksX0ma1gROTlovZKBmN08=
 github.com/ipfs/go-ipfs-blockstore v0.1.0/go.mod h1:5aD0AvHPi7mZc6Ci1WCAhiBQu2IsfTduLl+422H6Rqw=
@@ -778,6 +780,8 @@ github.com/ipfs/go-peertaskqueue v0.1.1/go.mod h1:Jmk3IyCcfl1W3jTW3YpghSwSEC6IJ3
 github.com/ipfs/go-peertaskqueue v0.2.0/go.mod h1:5/eNrBEbtSKWCG+kQK8K8fGNixoYUnr+P7jivavs9lY=
 github.com/ipfs/go-peertaskqueue v0.4.0 h1:x1hFgA4JOUJ3ntPfqLRu6v4k6kKL0p07r3RSg9JNyHI=
 github.com/ipfs/go-peertaskqueue v0.4.0/go.mod h1:KL9F49hXJMoXCad8e5anivjN+kWdr+CyGcyh4K6doLc=
+github.com/ipfs/go-peertaskqueue v0.6.0 h1:BT1/PuNViVomiz1PnnP5+WmKsTNHrxIDvkZrkj4JhOg=
+github.com/ipfs/go-peertaskqueue v0.6.0/go.mod h1:M/akTIE/z1jGNXMU7kFB4TeSEFvj68ow0Rrb04donIU=
 github.com/ipfs/go-todocounter v0.0.1/go.mod h1:l5aErvQc8qKE2r7NDMjmq5UNAvuZy0rC8BHOplkWvZ4=
 github.com/ipfs/go-unixfs v0.2.2-0.20190827150610-868af2e9e5cb/go.mod h1:IwAAgul1UQIcNZzKPYZWOCijryFBeCV79cNubPzol+k=
 github.com/ipfs/go-unixfs v0.2.4/go.mod h1:SUdisfUjNoSDzzhGVxvCL9QO/nKdwXdr+gbMUdqcbYw=


### PR DESCRIPTION
# Goals

Open the floodgates of data transfer, or at least figure out why they're not opening

# Implementation

Update for v0.10.3 of go-graphsync.

v0.10.3 has the following new configs that are used:
MaxInProgressIncomingRequestsPerPeer - set this at 20, which feels appropriate given that it's the default max a storage provider will do anyway for storage. This will prevent a single bad peer from dominating the transfer queue.
MessageSendRetries/SendMessageTimeout - this controls how long we take to fail at sending messages. Previously, these values were VERY HIGH. 10 minutes timeout + 10 retries. This sets it to numbers similar to Bitswap -- 2 minutes to try to send + 1 retry (BS takes one more attempt at sneding for want lists but actually does no retries for actual blocks)

Graphsync v0.10.3 also exposes some stats that will be useful for our graphana. Added a method to pipe these through.