### PR TITLE
Correct traversal options in SelectiveCar calls

### DIFF
--- a/filclient.go
+++ b/filclient.go
@@ -449,7 +449,13 @@ func (fc *FilClient) SendProposal(ctx context.Context, netprop *network.Proposal
 }
 
 func GeneratePieceCommitment(ctx context.Context, payloadCid cid.Cid, bstore blockstore.Blockstore) (cid.Cid, abi.UnpaddedPieceSize, error) {
-	selectiveCar := car.NewSelectiveCar(context.Background(), bstore, []car.Dag{{Root: payloadCid, Selector: shared.AllSelector()}}, car.MaxTraversalLinks(maxTraversalLinks))
+	selectiveCar := car.NewSelectiveCar(
+		context.Background(),
+		bstore,
+		[]car.Dag{{Root: payloadCid, Selector: shared.AllSelector()}},
+		car.MaxTraversalLinks(maxTraversalLinks),
+		car.TraverseLinksOnlyOnce(),
+	)
 	preparedCar, err := selectiveCar.Prepare()
 	if err != nil {
 		return cid.Undef, 0, err
@@ -475,7 +481,13 @@ func GeneratePieceCommitment(ctx context.Context, payloadCid cid.Cid, bstore blo
 }
 
 func GeneratePieceCommitmentFFI(ctx context.Context, payloadCid cid.Cid, bstore blockstore.Blockstore) (cid.Cid, abi.UnpaddedPieceSize, error) {
-	selectiveCar := car.NewSelectiveCar(context.Background(), bstore, []car.Dag{{Root: payloadCid, Selector: shared.AllSelector()}})
+	selectiveCar := car.NewSelectiveCar(
+		context.Background(),
+		bstore,
+		[]car.Dag{{Root: payloadCid, Selector: shared.AllSelector()}},
+		car.MaxTraversalLinks(maxTraversalLinks),
+		car.TraverseLinksOnlyOnce(),
+	)
 	preparedCar, err := selectiveCar.Prepare()
 	if err != nil {
 		return cid.Undef, 0, err


### PR DESCRIPTION
Without this we could and do exhaust the budget in "diamond-rich" DAGs

This should fix the following inconsistency:
```
~$ ipfs dag stat bafybeidtrl2wlaxotxavwowzdpnau7ftki2n4z6kebifmerowyijq5wosi
Size: 32559225580, NumBlocks: 158603
```
```
failed to compute commP for bafybeidtrl2wlaxotxavwowzdpnau7ftki2n4z6kebifmerowyijq5wosi: traversal budget exceeded: budget for links reached zero while on path "Links/44/Hash/Links/3/Hash/Links/0/Hash/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/next/0/refs/0/refs/0/refs/1/refs/0/refs/0/next/0/refs/0/next/0/next/0/next/0/next/0/refs/0/next/0/next/0/refs/0/refs/0/next/0" (link: "bafyreifafjpnxvcxrgvip6whbvukbwhdc5y75uldxfhagfpnton357ygdy")
```