### PR TITLE
fix: stop after the 1st successful retrieval

### DIFF
--- a/filc/retrieval.go
+++ b/filc/retrieval.go
@@ -348,7 +348,10 @@ func (node *Node) RetrieveFromBestCandidate(
 	attempts []RetrievalAttempt,
 ) (RetrievalStats, error) {
 	for _, attempt := range attempts {
-		attempt.Retrieve(ctx, node)
+		stats, err := attempt.Retrieve(ctx, node)
+		if err == nil {
+			return stats, nil
+		}
 	}
 
 	return nil, fmt.Errorf("all retrieval attempts failed")


### PR DESCRIPTION
if a retrieval succeeds, for instance over IPFS, currently `RetrieveFromBestCandidate` will keep going and try with the next candidate anyway (i.e. FIL), causing potentially multiple retrievals and seemingly failing under all circumstances.

in `filc` that means that the content is downloaded over IPFS, but is never saved locally if the FIL content retrieval fails.

I tested this by using `./filc/filc retrieve <locally pinned IPFS CID>`