### PR TITLE
Add datatransfer stages to ChannelState

### DIFF
--- a/filclient.go
+++ b/filclient.go
@@ -690,6 +690,8 @@ type ChannelState struct {
 
 	// Queued returns the number of bytes read from the node and queued for sending
 	//Queued uint64
+
+	Stages *datatransfer.ChannelStages
 }
 
 func ChannelStateConv(st datatransfer.ChannelState) *ChannelState {
@@ -703,6 +705,7 @@ func ChannelStateConv(st datatransfer.ChannelState) *ChannelState {
 		Message:    st.Message(),
 		BaseCid:    st.BaseCID().String(),
 		ChannelID:  st.ChannelID(),
+		Stages:     st.Stages(),
 		//Vouchers:          st.Vouchers(),
 		//VoucherResults:    st.VoucherResults(),
 		//LastVoucher:       st.LastVoucher(),


### PR DESCRIPTION
In Estuary, this is needed to track the various data transfer stages and their timestamps. This info can be used to set the data transfer completed timestamp (`transfer_finished` in the Estuary database). Right now, in the `content_deal` table, the `transfer_finished` column is not populated when a deal is sealed. This column is set at https://github.com/application-research/estuary/blob/master/replication.go#L1711

I have tested this by calling `TransferStatus(ctx, &chanid)` and I was able to get the timestamp for `transfer_finished` stage 

```
chanst, _ := cm.FilClient.TransferStatus(ctx, &chanid)
for _, s := range chanst.Stages.Stages {
	spew.Dump(s.Name, s.CreatedTime.Time(),)
}
// output
stage - (string) (len=16) "TransferFinished"
created_at - (time.Time) 2022-02-07 14:08:02.00764 +0100 WAT
```

NB: For Inprogress/ongoing data transfer, this info can also be retrieved by subscribing to data transfer events, but for already completed data transfers, subscribing to events (to the best of my knowledge) will not get us info. 

After this is merged, a PR will be created on Estuary side to use this feature