### PR TITLE
Record transfer type in channel state

### DIFF
--- a/filclient.go
+++ b/filclient.go
@@ -879,6 +879,13 @@ func (fc *FilClient) minerOwner(ctx context.Context, miner address.Address) (add
 	return minfo.Owner, nil
 }
 
+type TransferType string
+
+const (
+	BoostTransfer     TransferType = "boost"
+	GraphsyncTransfer TransferType = "graphsync"
+)
+
 type ChannelState struct {
 	//datatransfer.Channel
 
@@ -924,21 +931,24 @@ type ChannelState struct {
 	//Queued uint64
 
 	Stages *datatransfer.ChannelStages
+
+	TransferType TransferType
 }
 
 func ChannelStateConv(st datatransfer.ChannelState) *ChannelState {
 	return &ChannelState{
-		SelfPeer:   st.SelfPeer(),
-		RemotePeer: st.OtherPeer(),
-		Status:     st.Status(),
-		StatusStr:  datatransfer.Statuses[st.Status()],
-		Sent:       st.Sent(),
-		Received:   st.Received(),
-		Message:    st.Message(),
-		BaseCid:    st.BaseCID().String(),
-		ChannelID:  st.ChannelID(),
-		TransferID: st.ChannelID().String(),
-		Stages:     st.Stages(),
+		SelfPeer:     st.SelfPeer(),
+		RemotePeer:   st.OtherPeer(),
+		Status:       st.Status(),
+		StatusStr:    datatransfer.Statuses[st.Status()],
+		Sent:         st.Sent(),
+		Received:     st.Received(),
+		Message:      st.Message(),
+		BaseCid:      st.BaseCID().String(),
+		ChannelID:    st.ChannelID(),
+		TransferID:   st.ChannelID().String(),
+		Stages:       st.Stages(),
+		TransferType: GraphsyncTransfer,
 		//Vouchers:          st.Vouchers(),
 		//VoucherResults:    st.VoucherResults(),
 		//LastVoucher:       st.LastVoucher(),

--- a/libp2ptransfermgr.go
+++ b/libp2ptransfermgr.go
@@ -346,16 +346,17 @@ func (m *libp2pTransferManager) toDTState(st boosttypes.TransferState) ChannelSt
 	}
 
 	return ChannelState{
-		SelfPeer:   parsePeerID(st.LocalAddr),
-		RemotePeer: parsePeerID(remoteAddr),
-		Status:     status,
-		StatusStr:  datatransfer.Statuses[status],
-		Sent:       st.Sent,
-		Received:   st.Received,
-		Message:    st.Message,
-		BaseCid:    st.PayloadCid.String(),
-		ChannelID:  chid,
-		TransferID: st.ID,
+		SelfPeer:     parsePeerID(st.LocalAddr),
+		RemotePeer:   parsePeerID(remoteAddr),
+		Status:       status,
+		StatusStr:    datatransfer.Statuses[status],
+		Sent:         st.Sent,
+		Received:     st.Received,
+		Message:      st.Message,
+		BaseCid:      st.PayloadCid.String(),
+		ChannelID:    chid,
+		TransferID:   st.ID,
+		TransferType: BoostTransfer,
 	}
 }
 


### PR DESCRIPTION
On methods that return channel state, distinguish between Boost transfers and Graphsync transfers
(for future metrics)