### PR TITLE
Fix remote address empty on boost deals

### DIFF
--- a/libp2ptransfermgr.go
+++ b/libp2ptransfermgr.go
@@ -347,7 +347,7 @@ func (m *libp2pTransferManager) toDTState(st boosttypes.TransferState) ChannelSt
 
 	return ChannelState{
 		SelfPeer:   parsePeerID(st.LocalAddr),
-		RemotePeer: parsePeerID(st.RemoteAddr),
+		RemotePeer: parsePeerID(remoteAddr),
 		Status:     status,
 		StatusStr:  datatransfer.Statuses[status],
 		Sent:       st.Sent,


### PR DESCRIPTION
This fixes the bug that was causing these error messages: https://filecoinproject.slack.com/archives/C016APFREQK/p1654744991989739