### PR TITLE
fix: allow for nill PieceCIDs

### DIFF
--- a/filclient.go
+++ b/filclient.go
@@ -1546,13 +1546,17 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 
 	rootCid := proposal.PayloadCID
 	dealID := proposal.ID
+	pieceCid := cid.Undef
+	if proposal.PieceCID != nil {
+	  pieceCid = *proposal.PieceCID
+	}
 	allBytesReceived := false
 	dealComplete := false
 	receivedFirstByte := false
 
 	retrievalState := rep.RetrievalState{
 		PayloadCid:        rootCid,
-		PieceCid:          *proposal.PieceCID,
+		PieceCid:          pieceCid,
 		StorageProviderID: peerID,
 		ClientID:          chanid.Initiator,
 	}


### PR DESCRIPTION
They're allowed to be `nil` in proposals, and they're nil when created by `retrievehelper.RetrievalProposalForAsk()` which is what autoretrieve is using. `*foo` where `foo` is nill panics, so this panics. The empty value of a Cid is in `cid.Undef` for convenience: https://github.com/ipfs/go-cid/blob/8f7d7ac18e1c6ba7602c58dd02d99a8ace106fc3/cid.go#L155