### PR TITLE
feat: add EventType to retrieval events: query & retrieve

### DIFF
--- a/filclient.go
+++ b/filclient.go
@@ -1546,17 +1546,13 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 
 	rootCid := proposal.PayloadCID
 	dealID := proposal.ID
-	pieceCid := cid.Undef
-	if proposal.PieceCID != nil {
-	  pieceCid = *proposal.PieceCID
-	}
 	allBytesReceived := false
 	dealComplete := false
 	receivedFirstByte := false
 
 	retrievalState := rep.RetrievalState{
 		PayloadCid:        rootCid,
-		PieceCid:          pieceCid,
+		PieceCid:          proposal.PieceCID,
 		StorageProviderID: peerID,
 		ClientID:          chanid.Initiator,
 	}

--- a/filclient.go
+++ b/filclient.go
@@ -1329,7 +1329,11 @@ func (fc *FilClient) RetrievalQuery(ctx context.Context, maddr address.Address, 
 	s, err := fc.streamToMiner(ctx, maddr, RetrievalQueryProtocol)
 	if err != nil {
 		// publish fail event, log the err
-		retrievalEvent := rep.RetrievalEvent{Code: rep.RetrievalEventFailure, Status: fmt.Sprint("failed connecting to miner:", err)}
+		retrievalEvent := rep.RetrievalEvent{
+			Type:   rep.RetrievalQueryEvent,
+			Code:   rep.RetrievalEventFailure,
+			Status: fmt.Sprint("failed connecting to miner:", err),
+		}
 		fc.retrievalEventPublisher.Publish(retrievalEvent, retrievalState)
 
 		return nil, err
@@ -1338,7 +1342,11 @@ func (fc *FilClient) RetrievalQuery(ctx context.Context, maddr address.Address, 
 
 	// We have connected
 	// publish connected event
-	retrievalConnectedEvent := rep.RetrievalEvent{Code: rep.RetrievalEventConnect, Status: "connected to miner"}
+	retrievalConnectedEvent := rep.RetrievalEvent{
+		Type:   rep.RetrievalQueryEvent,
+		Code:   rep.RetrievalEventConnect,
+		Status: "connected to miner",
+	}
 	fc.retrievalEventPublisher.Publish(retrievalConnectedEvent, retrievalState)
 
 	q := &retrievalmarket.Query{
@@ -1348,7 +1356,11 @@ func (fc *FilClient) RetrievalQuery(ctx context.Context, maddr address.Address, 
 	var resp retrievalmarket.QueryResponse
 	if err := doRpc(ctx, s, q, &resp); err != nil {
 		// publish failure event
-		retrievalEvent := rep.RetrievalEvent{Code: rep.RetrievalEventFailure, Status: fmt.Sprint("failed retrieval query ask:", err)}
+		retrievalEvent := rep.RetrievalEvent{
+			Type:   rep.RetrievalQueryEvent,
+			Code:   rep.RetrievalEventFailure,
+			Status: fmt.Sprint("failed retrieval query ask:", err),
+		}
 		fc.retrievalEventPublisher.Publish(retrievalEvent, retrievalState)
 
 		return nil, fmt.Errorf("retrieval query rpc: %w", err)
@@ -1375,7 +1387,11 @@ func (fc *FilClient) RetrievalQueryToPeer(ctx context.Context, minerPeer peer.Ad
 	s, err := fc.openStreamToPeer(ctx, minerPeer, RetrievalQueryProtocol)
 	if err != nil {
 		// publish fail event, log the err
-		retrievalEvent := rep.RetrievalEvent{Code: rep.RetrievalEventFailure, Status: fmt.Sprint("failed connecting to miner:", err)}
+		retrievalEvent := rep.RetrievalEvent{
+			Type:   rep.RetrievalQueryEvent,
+			Code:   rep.RetrievalEventFailure,
+			Status: fmt.Sprint("failed connecting to miner:", err),
+		}
 		fc.retrievalEventPublisher.Publish(retrievalEvent, retrievalState)
 
 		return nil, err
@@ -1384,7 +1400,11 @@ func (fc *FilClient) RetrievalQueryToPeer(ctx context.Context, minerPeer peer.Ad
 
 	// We have connected
 	// publish connected event
-	retrievalConnectedEvent := rep.RetrievalEvent{Code: rep.RetrievalEventConnect, Status: "connected to miner"}
+	retrievalConnectedEvent := rep.RetrievalEvent{
+		Type:   rep.RetrievalQueryEvent,
+		Code:   rep.RetrievalEventConnect,
+		Status: "connected to miner",
+	}
 	fc.retrievalEventPublisher.Publish(retrievalConnectedEvent, retrievalState)
 
 	q := &retrievalmarket.Query{
@@ -1394,14 +1414,22 @@ func (fc *FilClient) RetrievalQueryToPeer(ctx context.Context, minerPeer peer.Ad
 	var resp retrievalmarket.QueryResponse
 	if err := doRpc(ctx, s, q, &resp); err != nil {
 		// publish failure event
-		retrievalEvent := rep.RetrievalEvent{Code: rep.RetrievalEventFailure, Status: fmt.Sprint("failed retrieval query ask:", err)}
+		retrievalEvent := rep.RetrievalEvent{
+			Type:   rep.RetrievalQueryEvent,
+			Code:   rep.RetrievalEventFailure,
+			Status: fmt.Sprint("failed retrieval query ask:", err),
+		}
 		fc.retrievalEventPublisher.Publish(retrievalEvent, retrievalState)
 
 		return nil, fmt.Errorf("retrieval query rpc: %w", err)
 	}
 
 	// publish query ask event
-	retrievalQueryAskEvent := rep.RetrievalEvent{Code: rep.RetrievalEventQueryAsk, Status: "retrieval query ask response submitted and received"}
+	retrievalQueryAskEvent := rep.RetrievalEvent{
+		Type:   rep.RetrievalQueryEvent,
+		Code:   rep.RetrievalEventQueryAsk,
+		Status: "retrieval query ask response submitted and received",
+	}
 	fc.retrievalEventPublisher.Publish(retrievalQueryAskEvent, retrievalState)
 
 	return &resp, nil
@@ -1601,7 +1629,11 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 					log.Info("Deal accepted")
 
 					// publish deal accepted event
-					retrievalEvent := rep.RetrievalEvent{Code: rep.RetrievalEventAccepted, Status: "deal accepted"}
+					retrievalEvent := rep.RetrievalEvent{
+						Type:   rep.RetrieveContentEvent,
+						Code:   rep.RetrievalEventAccepted,
+						Status: "deal accepted",
+					}
 					fc.retrievalEventPublisher.Publish(retrievalEvent, retrievalState)
 
 				// Respond with a payment voucher when funds are requested
@@ -1686,7 +1718,11 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 			// publish first byte event
 			if !receivedFirstByte {
 				receivedFirstByte = true
-				retrievalEvent := rep.RetrievalEvent{Code: rep.RetrievalEventFirstByte, Status: "received first byte"}
+				retrievalEvent := rep.RetrievalEvent{
+					Type:   rep.RetrieveContentEvent,
+					Code:   rep.RetrievalEventFirstByte,
+					Status: "received first byte",
+				}
 				fc.retrievalEventPublisher.Publish(retrievalEvent, retrievalState)
 			}
 
@@ -1722,7 +1758,11 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 	if err != nil {
 		// We could fail before a successful proposal
 		// publish event failure
-		retrievalEvent := rep.RetrievalEvent{Code: rep.RetrievalEventFailure, Status: fmt.Sprint("deal proposal failed:", err)}
+		retrievalEvent := rep.RetrievalEvent{
+			Type:   rep.RetrieveContentEvent,
+			Code:   rep.RetrievalEventFailure,
+			Status: fmt.Sprint("deal proposal failed:", err),
+		}
 		fc.retrievalEventPublisher.Publish(retrievalEvent, retrievalState)
 
 		return nil, err
@@ -1730,7 +1770,11 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 
 	// Deal has been proposed
 	// publish deal proposed event
-	retrievalEvent := rep.RetrievalEvent{Code: rep.RetrievalEventProposed, Status: "deal proposal"}
+	retrievalEvent := rep.RetrievalEvent{
+		Type:   rep.RetrieveContentEvent,
+		Code:   rep.RetrievalEventProposed,
+		Status: "deal proposal",
+	}
 	fc.retrievalEventPublisher.Publish(retrievalEvent, retrievalState)
 
 	chanidLk.Lock()
@@ -1744,7 +1788,11 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 	case err := <-dtRes:
 		if err != nil {
 			// If there is an error, publish a retrieval event failure
-			retrievalEvent := rep.RetrievalEvent{Code: rep.RetrievalEventFailure, Status: fmt.Sprint(err)}
+			retrievalEvent := rep.RetrievalEvent{
+				Type:   rep.RetrieveContentEvent,
+				Code:   rep.RetrievalEventFailure,
+				Status: fmt.Sprint(err),
+			}
 			fc.retrievalEventPublisher.Publish(retrievalEvent, retrievalState)
 
 			return nil, fmt.Errorf("data transfer failed: %w", err)
@@ -1755,7 +1803,11 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 		retrievalState.FinishedTime = finishedTime
 
 		// Otherwise publish a retrieval event success
-		retrievalEvent := rep.RetrievalEvent{Code: rep.RetrievalEventSuccess, Status: "data transfer for retrieval complete"}
+		retrievalEvent := rep.RetrievalEvent{
+			Type:   rep.RetrieveContentEvent,
+			Code:   rep.RetrievalEventSuccess,
+			Status: "data transfer for retrieval complete",
+		}
 		fc.retrievalEventPublisher.Publish(retrievalEvent, retrievalState)
 
 	case <-ctx.Done():

--- a/filclient.go
+++ b/filclient.go
@@ -1330,7 +1330,7 @@ func (fc *FilClient) RetrievalQuery(ctx context.Context, maddr address.Address, 
 	if err != nil {
 		// publish fail event, log the err
 		retrievalEvent := rep.RetrievalEvent{
-			Type:   rep.RetrievalQueryEvent,
+			Phase:  rep.QueryPhase,
 			Code:   rep.RetrievalEventFailure,
 			Status: fmt.Sprint("failed connecting to miner:", err),
 		}
@@ -1343,7 +1343,7 @@ func (fc *FilClient) RetrievalQuery(ctx context.Context, maddr address.Address, 
 	// We have connected
 	// publish connected event
 	retrievalConnectedEvent := rep.RetrievalEvent{
-		Type:   rep.RetrievalQueryEvent,
+		Phase:  rep.QueryPhase,
 		Code:   rep.RetrievalEventConnect,
 		Status: "connected to miner",
 	}
@@ -1357,7 +1357,7 @@ func (fc *FilClient) RetrievalQuery(ctx context.Context, maddr address.Address, 
 	if err := doRpc(ctx, s, q, &resp); err != nil {
 		// publish failure event
 		retrievalEvent := rep.RetrievalEvent{
-			Type:   rep.RetrievalQueryEvent,
+			Phase:  rep.QueryPhase,
 			Code:   rep.RetrievalEventFailure,
 			Status: fmt.Sprint("failed retrieval query ask:", err),
 		}
@@ -1367,7 +1367,12 @@ func (fc *FilClient) RetrievalQuery(ctx context.Context, maddr address.Address, 
 	}
 
 	// publish query ask event
-	retrievalQueryAskEvent := rep.RetrievalEvent{Code: rep.RetrievalEventQueryAsk, Status: "retrieval query ask response submitted and received"}
+	retrievalQueryAskEvent := rep.RetrievalEvent{
+		Phase:         rep.QueryPhase,
+		Code:          rep.RetrievalEventQueryAsk,
+		Status:        "retrieval query ask response submitted and received",
+		QueryResponse: &resp,
+	}
 	fc.retrievalEventPublisher.Publish(retrievalQueryAskEvent, retrievalState)
 
 	return &resp, nil
@@ -1388,7 +1393,7 @@ func (fc *FilClient) RetrievalQueryToPeer(ctx context.Context, minerPeer peer.Ad
 	if err != nil {
 		// publish fail event, log the err
 		retrievalEvent := rep.RetrievalEvent{
-			Type:   rep.RetrievalQueryEvent,
+			Phase:  rep.QueryPhase,
 			Code:   rep.RetrievalEventFailure,
 			Status: fmt.Sprint("failed connecting to miner:", err),
 		}
@@ -1401,7 +1406,7 @@ func (fc *FilClient) RetrievalQueryToPeer(ctx context.Context, minerPeer peer.Ad
 	// We have connected
 	// publish connected event
 	retrievalConnectedEvent := rep.RetrievalEvent{
-		Type:   rep.RetrievalQueryEvent,
+		Phase:  rep.QueryPhase,
 		Code:   rep.RetrievalEventConnect,
 		Status: "connected to miner",
 	}
@@ -1415,7 +1420,7 @@ func (fc *FilClient) RetrievalQueryToPeer(ctx context.Context, minerPeer peer.Ad
 	if err := doRpc(ctx, s, q, &resp); err != nil {
 		// publish failure event
 		retrievalEvent := rep.RetrievalEvent{
-			Type:   rep.RetrievalQueryEvent,
+			Phase:  rep.QueryPhase,
 			Code:   rep.RetrievalEventFailure,
 			Status: fmt.Sprint("failed retrieval query ask:", err),
 		}
@@ -1426,9 +1431,10 @@ func (fc *FilClient) RetrievalQueryToPeer(ctx context.Context, minerPeer peer.Ad
 
 	// publish query ask event
 	retrievalQueryAskEvent := rep.RetrievalEvent{
-		Type:   rep.RetrievalQueryEvent,
-		Code:   rep.RetrievalEventQueryAsk,
-		Status: "retrieval query ask response submitted and received",
+		Phase:         rep.QueryPhase,
+		Code:          rep.RetrievalEventQueryAsk,
+		Status:        "retrieval query ask response submitted and received",
+		QueryResponse: &resp,
 	}
 	fc.retrievalEventPublisher.Publish(retrievalQueryAskEvent, retrievalState)
 
@@ -1538,6 +1544,17 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 	startTime := time.Now()
 	totalPayment := abi.NewTokenAmount(0)
 
+	rootCid := proposal.PayloadCID
+	var chanid datatransfer.ChannelID
+	var chanidLk sync.Mutex
+
+	retrievalState := rep.RetrievalState{
+		PayloadCid:        rootCid,
+		PieceCid:          proposal.PieceCID,
+		StorageProviderID: peerID,
+		ClientID:          chanid.Initiator,
+	}
+
 	pchRequired := !proposal.PricePerByte.IsZero() || !proposal.UnsealPrice.IsZero()
 	var pchAddr address.Address
 	var pchLane uint64
@@ -1545,16 +1562,25 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 		// Get the payment channel and create a lane for this retrieval
 		pchAddr, err := fc.getPaychWithMinFunds(ctx, minerWallet)
 		if err != nil {
+			retrievalEvent := rep.RetrievalEvent{
+				Phase:  rep.RetrievalPhase,
+				Code:   rep.RetrievalEventFailure,
+				Status: fmt.Sprintf("failed to get payment channel: %s", err.Error()),
+			}
+			fc.retrievalEventPublisher.Publish(retrievalEvent, retrievalState)
 			return nil, fmt.Errorf("failed to get payment channel: %w", err)
 		}
 		pchLane, err = fc.pchmgr.AllocateLane(ctx, pchAddr)
 		if err != nil {
+			retrievalEvent := rep.RetrievalEvent{
+				Phase:  rep.RetrievalPhase,
+				Code:   rep.RetrievalEventFailure,
+				Status: fmt.Sprintf("failed to allocate lane: %s", err.Error()),
+			}
+			fc.retrievalEventPublisher.Publish(retrievalEvent, retrievalState)
 			return nil, fmt.Errorf("failed to allocate lane: %w", err)
 		}
 	}
-
-	var chanid datatransfer.ChannelID
-	var chanidLk sync.Mutex
 
 	// Set up incoming events handler
 
@@ -1572,18 +1598,10 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 		}
 	}
 
-	rootCid := proposal.PayloadCID
 	dealID := proposal.ID
 	allBytesReceived := false
 	dealComplete := false
 	receivedFirstByte := false
-
-	retrievalState := rep.RetrievalState{
-		PayloadCid:        rootCid,
-		PieceCid:          proposal.PieceCID,
-		StorageProviderID: peerID,
-		ClientID:          chanid.Initiator,
-	}
 
 	unsubscribe := fc.dataTransfer.SubscribeToEvents(func(event datatransfer.Event, state datatransfer.ChannelState) {
 		// Copy chanid so it can be used later in the callback
@@ -1630,7 +1648,7 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 
 					// publish deal accepted event
 					retrievalEvent := rep.RetrievalEvent{
-						Type:   rep.RetrieveContentEvent,
+						Phase:  rep.RetrievalPhase,
 						Code:   rep.RetrievalEventAccepted,
 						Status: "deal accepted",
 					}
@@ -1719,7 +1737,7 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 			if !receivedFirstByte {
 				receivedFirstByte = true
 				retrievalEvent := rep.RetrievalEvent{
-					Type:   rep.RetrieveContentEvent,
+					Phase:  rep.RetrievalPhase,
 					Code:   rep.RetrievalEventFirstByte,
 					Status: "received first byte",
 				}
@@ -1759,7 +1777,7 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 		// We could fail before a successful proposal
 		// publish event failure
 		retrievalEvent := rep.RetrievalEvent{
-			Type:   rep.RetrieveContentEvent,
+			Phase:  rep.RetrievalPhase,
 			Code:   rep.RetrievalEventFailure,
 			Status: fmt.Sprint("deal proposal failed:", err),
 		}
@@ -1771,7 +1789,7 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 	// Deal has been proposed
 	// publish deal proposed event
 	retrievalEvent := rep.RetrievalEvent{
-		Type:   rep.RetrieveContentEvent,
+		Phase:  rep.RetrievalPhase,
 		Code:   rep.RetrievalEventProposed,
 		Status: "deal proposal",
 	}
@@ -1789,9 +1807,9 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 		if err != nil {
 			// If there is an error, publish a retrieval event failure
 			retrievalEvent := rep.RetrievalEvent{
-				Type:   rep.RetrieveContentEvent,
+				Phase:  rep.RetrievalPhase,
 				Code:   rep.RetrievalEventFailure,
-				Status: fmt.Sprint(err),
+				Status: err.Error(),
 			}
 			fc.retrievalEventPublisher.Publish(retrievalEvent, retrievalState)
 
@@ -1801,14 +1819,6 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 		log.Debugf("data transfer for retrieval complete")
 		finishedTime := time.Now()
 		retrievalState.FinishedTime = finishedTime
-
-		// Otherwise publish a retrieval event success
-		retrievalEvent := rep.RetrievalEvent{
-			Type:   rep.RetrieveContentEvent,
-			Code:   rep.RetrievalEventSuccess,
-			Status: "data transfer for retrieval complete",
-		}
-		fc.retrievalEventPublisher.Publish(retrievalEvent, retrievalState)
 
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -1823,6 +1833,16 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 
 	duration := time.Since(startTime)
 	speed := uint64(float64(state.Received()) / duration.Seconds())
+
+	retrievalState.ReceivedSize = state.Received()
+
+	// Otherwise publish a retrieval event success
+	retrievalEvent = rep.RetrievalEvent{
+		Phase:  rep.RetrievalPhase,
+		Code:   rep.RetrievalEventSuccess,
+		Status: "data transfer for retrieval complete",
+	}
+	fc.retrievalEventPublisher.Publish(retrievalEvent, retrievalState)
 
 	return &RetrievalStats{
 		Peer:         state.OtherPeer(),

--- a/filclient.go
+++ b/filclient.go
@@ -1546,13 +1546,17 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 
 	rootCid := proposal.PayloadCID
 	dealID := proposal.ID
+	pieceCid := cid.Undef
+	if proposal.PieceCID != nil {
+	  pieceCid = *proposal.PieceCID
+	}
 	allBytesReceived := false
 	dealComplete := false
 	receivedFirstByte := false
 
 	retrievalState := rep.RetrievalState{
 		PayloadCid:        rootCid,
-		PieceCid:          *proposal.PieceCID,
+		PieceCid:          pieceCid,
 		StorageProviderID: peerID,
 		ClientID:          chanid.Initiator,
 	}

--- a/rep/event.go
+++ b/rep/event.go
@@ -29,7 +29,7 @@ type RetrievalEvent struct {
 // needs to be stateful in the future, implement as a state machine.
 type RetrievalState struct {
 	PayloadCid          cid.Cid
-	PieceCid            cid.Cid
+	PieceCid            *cid.Cid
 	StorageProviderID   peer.ID
 	StorageProviderAddr address.Address
 	ClientID            peer.ID

--- a/rep/event.go
+++ b/rep/event.go
@@ -8,6 +8,13 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
+type EventType string
+
+const (
+	RetrievalQueryEvent  EventType = "query"
+	RetrieveContentEvent EventType = "retrieve"
+)
+
 type RetrievalEventCode string
 
 const (
@@ -21,6 +28,7 @@ const (
 )
 
 type RetrievalEvent struct {
+	Type   EventType
 	Code   RetrievalEventCode
 	Status string
 }

--- a/rep/event.go
+++ b/rep/event.go
@@ -4,15 +4,18 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
-type EventType string
+type Phase string
 
 const (
-	RetrievalQueryEvent  EventType = "query"
-	RetrieveContentEvent EventType = "retrieve"
+	// QueryPhase involves a connect, query-ask, success|failure
+	QueryPhase Phase = "query"
+	// RetrievalPhase involves the full data retrieval: connect, proposed, accepted, first-byte-received, success|failure
+	RetrievalPhase Phase = "retrieval"
 )
 
 type RetrievalEventCode string
@@ -28,9 +31,12 @@ const (
 )
 
 type RetrievalEvent struct {
-	Type   EventType
-	Code   RetrievalEventCode
+	Phase Phase
+	Code  RetrievalEventCode
+	// Status will include error messages for RetrievalEventFailure, other events use it to expand the Code description
 	Status string
+	// QueryResponse will be included for a RetrievalEventQueryAsk event
+	QueryResponse *retrievalmarket.QueryResponse
 }
 
 // TODO: This is moreso retrieval properties than state. If this
@@ -42,4 +48,5 @@ type RetrievalState struct {
 	StorageProviderAddr address.Address
 	ClientID            peer.ID
 	FinishedTime        time.Time
+	ReceivedSize        uint64
 }


### PR DESCRIPTION
Builds on #86. 

When a client first does a Query followed by a Retrieve, a racy event publisher means we can't distinguish which events were triggered by which action.

An alternative to this might be to accept some kind of ID with the original request that comes back in the events. But this is the least disruptive in API terms for now I think.

(sitting on this as a draft for now because I haven't quite solved all my race problems yet and this might not be enough)