### PR TITLE
feat: rework retrieval events

### DIFF
--- a/rep/event.go
+++ b/rep/event.go
@@ -1,8 +1,6 @@
 package rep
 
 import (
-	"time"
-
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/ipfs/go-cid"
@@ -18,35 +16,171 @@ const (
 	RetrievalPhase Phase = "retrieval"
 )
 
-type RetrievalEventCode string
+type Code string
 
 const (
-	RetrievalEventConnect   RetrievalEventCode = "connected"
-	RetrievalEventQueryAsk  RetrievalEventCode = "query-asked"
-	RetrievalEventProposed  RetrievalEventCode = "proposed"
-	RetrievalEventAccepted  RetrievalEventCode = "accepted"
-	RetrievalEventFirstByte RetrievalEventCode = "first-byte-received"
-	RetrievalEventFailure   RetrievalEventCode = "failure"
-	RetrievalEventSuccess   RetrievalEventCode = "success"
+	ConnectedCode  Code = "connected"
+	QueryAskedCode Code = "query-asked"
+	ProposedCode   Code = "proposed"
+	AcceptedCode   Code = "accepted"
+	FirstByteCode  Code = "first-byte-received"
+	FailureCode    Code = "failure"
+	SuccessCode    Code = "success"
 )
 
-type RetrievalEvent struct {
-	Phase Phase
-	Code  RetrievalEventCode
-	// Status will include error messages for RetrievalEventFailure, other events use it to expand the Code description
-	Status string
-	// QueryResponse will be included for a RetrievalEventQueryAsk event
-	QueryResponse *retrievalmarket.QueryResponse
+type RetrievalEvent interface {
+	// Code returns the type of event this is
+	Code() Code
+	// Phase returns what phase of a retrieval this even occurred on
+	Phase() Phase
+	// PayloadCid returns the CID being requested
+	PayloadCid() cid.Cid
+	// StorageProviderId returns the peer ID of the storage provider if this
+	// retrieval was requested via peer ID
+	StorageProviderId() peer.ID
+	// StorageProviderAddr returns the peer address of the storage provider if
+	// this retrieval was requested via peer address
+	StorageProviderAddr() address.Address
 }
 
-// TODO: This is moreso retrieval properties than state. If this
-// needs to be stateful in the future, implement as a state machine.
-type RetrievalState struct {
-	PayloadCid          cid.Cid
-	PieceCid            *cid.Cid
-	StorageProviderID   peer.ID
-	StorageProviderAddr address.Address
-	ClientID            peer.ID
-	FinishedTime        time.Time
-	ReceivedSize        uint64
+var (
+	_ RetrievalEvent = RetrievalEventConnect{}
+	_ RetrievalEvent = RetrievalEventQueryAsk{}
+	_ RetrievalEvent = RetrievalEventProposed{}
+	_ RetrievalEvent = RetrievalEventAccepted{}
+	_ RetrievalEvent = RetrievalEventFirstByte{}
+	_ RetrievalEvent = RetrievalEventFailure{}
+	_ RetrievalEvent = RetrievalEventSuccess{}
+)
+
+type RetrievalEventConnect struct {
+	phase               Phase
+	payloadCid          cid.Cid
+	storageProviderId   peer.ID
+	storageProviderAddr address.Address
 }
+
+func NewRetrievalEventConnect(phase Phase, payloadCid cid.Cid, storageProviderId peer.ID, storageProviderAddr address.Address) RetrievalEventConnect {
+	return RetrievalEventConnect{phase, payloadCid, storageProviderId, storageProviderAddr}
+}
+
+type RetrievalEventQueryAsk struct {
+	phase               Phase
+	payloadCid          cid.Cid
+	storageProviderId   peer.ID
+	storageProviderAddr address.Address
+	queryResponse       retrievalmarket.QueryResponse
+}
+
+func NewRetrievalEventQueryAsk(phase Phase, payloadCid cid.Cid, storageProviderId peer.ID, storageProviderAddr address.Address, queryResponse retrievalmarket.QueryResponse) RetrievalEventQueryAsk {
+	return RetrievalEventQueryAsk{phase, payloadCid, storageProviderId, storageProviderAddr, queryResponse}
+}
+
+type RetrievalEventProposed struct {
+	phase               Phase
+	payloadCid          cid.Cid
+	storageProviderId   peer.ID
+	storageProviderAddr address.Address
+}
+
+func NewRetrievalEventProposed(phase Phase, payloadCid cid.Cid, storageProviderId peer.ID, storageProviderAddr address.Address) RetrievalEventProposed {
+	return RetrievalEventProposed{phase, payloadCid, storageProviderId, storageProviderAddr}
+}
+
+type RetrievalEventAccepted struct {
+	phase               Phase
+	payloadCid          cid.Cid
+	storageProviderId   peer.ID
+	storageProviderAddr address.Address
+}
+
+func NewRetrievalEventAccepted(phase Phase, payloadCid cid.Cid, storageProviderId peer.ID, storageProviderAddr address.Address) RetrievalEventAccepted {
+	return RetrievalEventAccepted{phase, payloadCid, storageProviderId, storageProviderAddr}
+}
+
+type RetrievalEventFirstByte struct {
+	phase               Phase
+	payloadCid          cid.Cid
+	storageProviderId   peer.ID
+	storageProviderAddr address.Address
+}
+
+func NewRetrievalEventFirstByte(phase Phase, payloadCid cid.Cid, storageProviderId peer.ID, storageProviderAddr address.Address) RetrievalEventFirstByte {
+	return RetrievalEventFirstByte{phase, payloadCid, storageProviderId, storageProviderAddr}
+}
+
+type RetrievalEventFailure struct {
+	phase               Phase
+	payloadCid          cid.Cid
+	storageProviderId   peer.ID
+	storageProviderAddr address.Address
+	errorMessage        string
+}
+
+func NewRetrievalEventFailure(phase Phase, payloadCid cid.Cid, storageProviderId peer.ID, storageProviderAddr address.Address, errorMessage string) RetrievalEventFailure {
+	return RetrievalEventFailure{phase, payloadCid, storageProviderId, storageProviderAddr, errorMessage}
+}
+
+type RetrievalEventSuccess struct {
+	phase               Phase
+	payloadCid          cid.Cid
+	storageProviderId   peer.ID
+	storageProviderAddr address.Address
+	receivedSize        uint64
+	receivedCids        int64
+}
+
+func NewRetrievalEventSuccess(phase Phase, payloadCid cid.Cid, storageProviderId peer.ID, storageProviderAddr address.Address, receivedSize uint64, receivedCids int64) RetrievalEventSuccess {
+	return RetrievalEventSuccess{phase, payloadCid, storageProviderId, storageProviderAddr, receivedSize, receivedCids}
+}
+
+func (r RetrievalEventConnect) Code() Code                            { return ConnectedCode }
+func (r RetrievalEventConnect) Phase() Phase                          { return r.phase }
+func (r RetrievalEventConnect) PayloadCid() cid.Cid                   { return r.payloadCid }
+func (r RetrievalEventConnect) StorageProviderId() peer.ID            { return r.storageProviderId }
+func (r RetrievalEventConnect) StorageProviderAddr() address.Address  { return r.storageProviderAddr }
+func (r RetrievalEventQueryAsk) Code() Code                           { return QueryAskedCode }
+func (r RetrievalEventQueryAsk) Phase() Phase                         { return r.phase }
+func (r RetrievalEventQueryAsk) PayloadCid() cid.Cid                  { return r.payloadCid }
+func (r RetrievalEventQueryAsk) StorageProviderId() peer.ID           { return r.storageProviderId }
+func (r RetrievalEventQueryAsk) StorageProviderAddr() address.Address { return r.storageProviderAddr }
+
+// QueryResponse returns the response from a storage provider to a query-ask
+func (r RetrievalEventQueryAsk) QueryResponse() retrievalmarket.QueryResponse { return r.queryResponse }
+func (r RetrievalEventProposed) Code() Code                                   { return ProposedCode }
+func (r RetrievalEventProposed) Phase() Phase                                 { return r.phase }
+func (r RetrievalEventProposed) PayloadCid() cid.Cid                          { return r.payloadCid }
+func (r RetrievalEventProposed) StorageProviderId() peer.ID                   { return r.storageProviderId }
+func (r RetrievalEventProposed) StorageProviderAddr() address.Address         { return r.storageProviderAddr }
+func (r RetrievalEventAccepted) Code() Code                                   { return AcceptedCode }
+func (r RetrievalEventAccepted) Phase() Phase                                 { return r.phase }
+func (r RetrievalEventAccepted) PayloadCid() cid.Cid                          { return r.payloadCid }
+func (r RetrievalEventAccepted) StorageProviderId() peer.ID                   { return r.storageProviderId }
+func (r RetrievalEventAccepted) StorageProviderAddr() address.Address         { return r.storageProviderAddr }
+func (r RetrievalEventFirstByte) Code() Code                                  { return FirstByteCode }
+func (r RetrievalEventFirstByte) Phase() Phase                                { return r.phase }
+func (r RetrievalEventFirstByte) PayloadCid() cid.Cid                         { return r.payloadCid }
+func (r RetrievalEventFirstByte) StorageProviderId() peer.ID                  { return r.storageProviderId }
+func (r RetrievalEventFirstByte) StorageProviderAddr() address.Address        { return r.storageProviderAddr }
+func (r RetrievalEventFailure) Code() Code                                    { return FailureCode }
+func (r RetrievalEventFailure) Phase() Phase                                  { return r.phase }
+func (r RetrievalEventFailure) PayloadCid() cid.Cid                           { return r.payloadCid }
+func (r RetrievalEventFailure) StorageProviderId() peer.ID                    { return r.storageProviderId }
+func (r RetrievalEventFailure) StorageProviderAddr() address.Address          { return r.storageProviderAddr }
+
+// ErrorMessage returns a string form of the error that caused the retrieval
+// failure
+func (r RetrievalEventFailure) ErrorMessage() string                 { return r.errorMessage }
+func (r RetrievalEventSuccess) Code() Code                           { return SuccessCode }
+func (r RetrievalEventSuccess) Phase() Phase                         { return r.phase }
+func (r RetrievalEventSuccess) PayloadCid() cid.Cid                  { return r.payloadCid }
+func (r RetrievalEventSuccess) StorageProviderId() peer.ID           { return r.storageProviderId }
+func (r RetrievalEventSuccess) StorageProviderAddr() address.Address { return r.storageProviderAddr }
+
+// ReceivedSize returns the number of bytes received
+func (r RetrievalEventSuccess) ReceivedSize() uint64 { return r.receivedSize }
+
+// ReceivedCids returns the number of (non-unique) CIDs received so far - note
+// that a block can exist in more than one place in the DAG so this may not
+// equal the total number of blocks transferred
+func (r RetrievalEventSuccess) ReceivedCids() int64 { return r.receivedCids }

--- a/rep/publisher_test.go
+++ b/rep/publisher_test.go
@@ -1,35 +1,81 @@
 package rep_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/application-research/filclient/rep"
+	"github.com/filecoin-project/go-address"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/require"
 )
 
-type unindexableStruct struct {
-	events []rep.RetrievalEvent
+var testCid1 cid.Cid = mustCid("bafybeihrqe2hmfauph5yfbd6ucv7njqpiy4tvbewlvhzjl4bhnyiu6h7pm")
+
+type sub struct {
+	ping chan rep.RetrievalEvent
 }
 
-func (us *unindexableStruct) OnRetrievalEvent(evt rep.RetrievalEvent, state rep.RetrievalState) {
-	us.events = append(us.events, evt)
+func (us *sub) OnRetrievalEvent(evt rep.RetrievalEvent) {
+	if us.ping != nil {
+		us.ping <- evt
+	}
 }
 
-func (us *unindexableStruct) RetrievalSubscriberId() interface{} {
-	return "unindexableStruct_0"
-}
+func TestSubscribeAndUnsubscribe(t *testing.T) {
+	pub := rep.New(context.Background())
+	sub := &sub{}
+	require.Equal(t, 0, pub.SubscriberCount(), "has no subscribers")
 
-func TestNoPanicOnUnindexableStruct(t *testing.T) {
-	pub := rep.New()
-	sub := &unindexableStruct{}
 	unsub := pub.Subscribe(sub)
-	pub.Subscribe(sub)
+	unsub2 := pub.Subscribe(sub)
 
-	if pub.SubscriberCount() != 1 {
-		t.Fatal("should have deduped subscribers, but didn't")
-	}
-
+	require.Equal(t, 2, pub.SubscriberCount(), "registered both subscribers")
 	unsub()
-	if pub.SubscriberCount() != 0 {
-		t.Fatal("should have unsubscribed but didn't")
+	require.Equal(t, 1, pub.SubscriberCount(), "unregistered first subscriber")
+	unsub2()
+	require.Equal(t, 0, pub.SubscriberCount(), "unregistered second subscriber")
+}
+
+func TestEventing(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	pub := rep.New(ctx)
+	sub := &sub{ping: make(chan rep.RetrievalEvent)}
+
+	pub.Subscribe(sub)
+	pid := peer.NewPeerRecord().PeerID
+	pub.Publish(rep.NewRetrievalEventConnect(rep.QueryPhase, testCid1, pid, address.Undef))
+	pub.Publish(rep.NewRetrievalEventSuccess(rep.RetrievalPhase, testCid1, "", address.TestAddress, 101, 202))
+
+	evt := <-sub.ping
+	require.Equal(t, rep.QueryPhase, evt.Phase())
+	require.Equal(t, testCid1, evt.PayloadCid())
+	require.Equal(t, pid, evt.StorageProviderId())
+	require.Equal(t, address.Undef, evt.StorageProviderAddr())
+	require.Equal(t, rep.ConnectedCode, evt.Code())
+	_, ok := evt.(rep.RetrievalEventConnect)
+	require.True(t, ok)
+
+	evt = <-sub.ping
+	require.Equal(t, rep.RetrievalPhase, evt.Phase())
+	require.Equal(t, testCid1, evt.PayloadCid())
+	require.Equal(t, peer.ID(""), evt.StorageProviderId())
+	require.Equal(t, address.TestAddress, evt.StorageProviderAddr())
+	require.Equal(t, rep.SuccessCode, evt.Code())
+	res, ok := evt.(rep.RetrievalEventSuccess)
+	require.True(t, ok)
+	require.Equal(t, uint64(101), res.ReceivedSize())
+	require.Equal(t, int64(202), res.ReceivedCids())
+}
+
+func mustCid(cstr string) cid.Cid {
+	c, err := cid.Decode(cstr)
+	if err != nil {
+		panic(err)
 	}
+	return c
 }

--- a/rep/subscriber.go
+++ b/rep/subscriber.go
@@ -1,9 +1,0 @@
-package rep
-
-type OnRetrievalEvent func()
-
-type RetrievalSubscriber interface {
-	OnRetrievalEvent(RetrievalEvent, RetrievalState)
-	// RetrievalSubscriberId must return a unique identifier of a comparable type for this subscriber
-	RetrievalSubscriberId() interface{}
-}


### PR DESCRIPTION
Draft for now, an attempt at reworking the event system now that autoretrieve is the only consumer. I've done away with the "status" object and have introduced typed events which are all the same but 3 have additional, specific fields: query-ask, failure & success. So for each of those, you can type cast and access the additional info.

I wanted to get this up so suggest how we could move beyond the awkwardness in #88 of hanging the `QueryResponse` in the event. But this PR isn't critical to get the autoretrieve work over the line, so I'm suggesting we merge #88 and treat this as a second stage of work.