### PR TITLE
fix: remove TraverseLinksOnlyOnce on piece CID

### DIFF
--- a/filclient.go
+++ b/filclient.go
@@ -668,7 +668,6 @@ func GeneratePieceCommitment(ctx context.Context, payloadCid cid.Cid, bstore blo
 		bstore,
 		[]car.Dag{{Root: payloadCid, Selector: shared.AllSelector()}},
 		car.MaxTraversalLinks(maxTraversalLinks),
-		car.TraverseLinksOnlyOnce(),
 	)
 	preparedCar, err := selectiveCar.Prepare()
 	if err != nil {
@@ -700,7 +699,6 @@ func GeneratePieceCommitmentFFI(ctx context.Context, payloadCid cid.Cid, bstore 
 		bstore,
 		[]car.Dag{{Root: payloadCid, Selector: shared.AllSelector()}},
 		car.MaxTraversalLinks(maxTraversalLinks),
-		car.TraverseLinksOnlyOnce(),
 	)
 	preparedCar, err := selectiveCar.Prepare()
 	if err != nil {


### PR DESCRIPTION
This follows lotus's implementation:
https://github.com/filecoin-project/lotus/blob/a843c52e38da13da489cbe6b290ea49b2660b3fb/node/impl/client/client.go#L1405-L1412

 I have no idea if that would fix things tho. (need tests)