### PR TITLE
Confirm block(s) received, and add additional reporting data

### DIFF
--- a/filclient.go
+++ b/filclient.go
@@ -1787,7 +1787,7 @@ func (fc *FilClient) RetrieveContentFromPeerWithProgressCallback(
 	speed := uint64(float64(state.Received()) / duration.Seconds())
 
 	// Otherwise publish a retrieval event success
-	fc.retrievalEventPublisher.Publish(rep.NewRetrievalEventSuccess(rep.RetrievalPhase, rootCid, peerID, address.Undef, state.Received(), state.ReceivedCidsTotal()))
+	fc.retrievalEventPublisher.Publish(rep.NewRetrievalEventSuccess(rep.RetrievalPhase, rootCid, peerID, address.Undef, state.Received(), state.ReceivedCidsTotal(), duration, totalPayment))
 
 	return &RetrievalStats{
 		Peer:         state.OtherPeer(),

--- a/rep/event.go
+++ b/rep/event.go
@@ -1,8 +1,11 @@
 package rep
 
 import (
+	"time"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
@@ -128,10 +131,12 @@ type RetrievalEventSuccess struct {
 	storageProviderAddr address.Address
 	receivedSize        uint64
 	receivedCids        int64
+	duration            time.Duration
+	totalPayment        big.Int
 }
 
-func NewRetrievalEventSuccess(phase Phase, payloadCid cid.Cid, storageProviderId peer.ID, storageProviderAddr address.Address, receivedSize uint64, receivedCids int64) RetrievalEventSuccess {
-	return RetrievalEventSuccess{phase, payloadCid, storageProviderId, storageProviderAddr, receivedSize, receivedCids}
+func NewRetrievalEventSuccess(phase Phase, payloadCid cid.Cid, storageProviderId peer.ID, storageProviderAddr address.Address, receivedSize uint64, receivedCids int64, duration time.Duration, totalPayment big.Int) RetrievalEventSuccess {
+	return RetrievalEventSuccess{phase, payloadCid, storageProviderId, storageProviderAddr, receivedSize, receivedCids, duration, totalPayment}
 }
 
 func (r RetrievalEventConnect) Code() Code                            { return ConnectedCode }
@@ -176,6 +181,8 @@ func (r RetrievalEventSuccess) Phase() Phase                         { return r.
 func (r RetrievalEventSuccess) PayloadCid() cid.Cid                  { return r.payloadCid }
 func (r RetrievalEventSuccess) StorageProviderId() peer.ID           { return r.storageProviderId }
 func (r RetrievalEventSuccess) StorageProviderAddr() address.Address { return r.storageProviderAddr }
+func (r RetrievalEventSuccess) Duration() time.Duration              { return r.duration }
+func (r RetrievalEventSuccess) TotalPayment() big.Int                { return r.totalPayment }
 
 // ReceivedSize returns the number of bytes received
 func (r RetrievalEventSuccess) ReceivedSize() uint64 { return r.receivedSize }

--- a/rep/publisher_test.go
+++ b/rep/publisher_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/application-research/filclient/rep"
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
@@ -49,7 +50,7 @@ func TestEventing(t *testing.T) {
 	pub.Subscribe(sub)
 	pid := peer.NewPeerRecord().PeerID
 	pub.Publish(rep.NewRetrievalEventConnect(rep.QueryPhase, testCid1, pid, address.Undef))
-	pub.Publish(rep.NewRetrievalEventSuccess(rep.RetrievalPhase, testCid1, "", address.TestAddress, 101, 202))
+	pub.Publish(rep.NewRetrievalEventSuccess(rep.RetrievalPhase, testCid1, "", address.TestAddress, 101, 202, time.Millisecond*303, abi.NewTokenAmount(404)))
 
 	evt := <-sub.ping
 	require.Equal(t, rep.QueryPhase, evt.Phase())
@@ -70,6 +71,8 @@ func TestEventing(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, uint64(101), res.ReceivedSize())
 	require.Equal(t, int64(202), res.ReceivedCids())
+	require.Equal(t, time.Millisecond*303, res.Duration())
+	require.Equal(t, abi.NewTokenAmount(404), res.TotalPayment())
 }
 
 func mustCid(cstr string) cid.Cid {


### PR DESCRIPTION
* check for potential data transfer errors, where DT reports success but the block(s) we wanted didn't end up in our blockstore. Ref: https://github.com/application-research/autoretrieve/pull/121
* add more info on success event

These two commits are not strictly related. As I was refactoring in autoretrieve to deal with the block-unconfirmed case I found I wanted more reporting data, so I'd added it in here, and then I decided that filclient was a better place to do the block confirmation anyway.

So this deals with the case where data transfer doesn't properly report on the status of a retrieval—it's possible to get "success" but no blocks transferred and the block(s) we want not being in the blockstore (i.e. no blocks being transferred is valid if we already had what we wanted). Doing the check in here also fixes it for CLI and other API usage (`filc retrieve ...` can result in a "not found" error from the blockstore in this case even after reporting a successful retrieval, it's how I first noticed it). You now get a proper error about your retrieval failing.