### PR TITLE
fix: improve uniqueness of DealID for retrievals

### DIFF
--- a/retrievehelper/params.go
+++ b/retrievehelper/params.go
@@ -1,18 +1,19 @@
 package retrievehelper
 
 import (
-	"math/rand"
-
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 )
+
+var dealIdGen = shared.NewTimeCounter()
 
 func RetrievalProposalForAsk(ask *retrievalmarket.QueryResponse, c cid.Cid, optionalSelector ipld.Node) (*retrievalmarket.DealProposal, error) {
 
 	if optionalSelector == nil {
-		optionalSelector = shared.AllSelector()
+		optionalSelector = selectorparse.CommonSelector_ExploreAllRecursively
 	}
 
 	params, err := retrievalmarket.NewParamsV1(
@@ -28,7 +29,7 @@ func RetrievalProposalForAsk(ask *retrievalmarket.QueryResponse, c cid.Cid, opti
 	}
 	return &retrievalmarket.DealProposal{
 		PayloadCID: c,
-		ID:         retrievalmarket.DealID(rand.Int63n(1000000) + 100000),
+		ID:         retrievalmarket.DealID(dealIdGen.Next()),
 		Params:     params,
 	}, nil
 }


### PR DESCRIPTION
Ref: https://github.com/application-research/autoretrieve/issues/120

SP's record retrieval deals unique by peer ID and deal ID. If a single peer makes enough retrievals to a single SP with a small unique deal ID space and they start to be reused then we can experience failures as the SP gets confused about what retrieval deal they're dealing with.

Current implementation here has a relatively small space, which is apparently getting exhausted by autoretrieve which makes a _lot_ of deals with any SP that will talk to it. This seems to be the cause of the large number of failures with:
	data transfer failed: datatransfer error: response rejected

This fix uses the deal ID generator from go-fil-markets that uses a monotonic set of IDs starting from the unixtime of instantiation. If no two instances using the same peer ID have a start time close to each other then we should have minimal to no overlaps (this might not work so well if we have multiple instances with the same peer ID in a cluster with similar start times...).