### PR TITLE
Expose option to set removeUnsealed when calling MakeDeal

### DIFF
--- a/filc/cmds.go
+++ b/filc/cmds.go
@@ -124,6 +124,7 @@ var makeDealCmd = &cli.Command{
 		}
 
 		verified := parseVerified(cctx)
+		removeUnsealed := parseRemoveUnsealed(cctx)
 
 		price := ask.Ask.Ask.Price
 		if verified {
@@ -134,7 +135,7 @@ var makeDealCmd = &cli.Command{
 		}
 
 		minPieceSize := ask.Ask.Ask.MinPieceSize
-		proposal, err := fc.MakeDeal(cctx.Context, miner, obj.Cid(), price, minPieceSize, 2880*365, verified)
+		proposal, err := fc.MakeDeal(cctx.Context, miner, obj.Cid(), price, minPieceSize, 2880*365, verified, removeUnsealed)
 		if err != nil {
 			return err
 		}

--- a/filc/flags.go
+++ b/filc/flags.go
@@ -1,6 +1,6 @@
 package main
 
-import cli "github.com/urfave/cli/v2"
+import "github.com/urfave/cli/v2"
 
 var flagMiner = &cli.StringFlag{
 	Name:    "miner",
@@ -26,6 +26,10 @@ var flagMinersRequired = &cli.StringSliceFlag{
 
 var flagVerified = &cli.BoolFlag{
 	Name: "verified",
+}
+
+var removeUnsealed = &cli.BoolFlag{
+	Name: "remove-unsealed",
 }
 
 var flagOutput = &cli.StringFlag{

--- a/filc/parsing.go
+++ b/filc/parsing.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/google/uuid"
-	cli "github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 // Read a single miner from the CLI, returning address.Undef if none is
@@ -51,6 +51,11 @@ func parseMiners(cctx *cli.Context) ([]address.Address, error) {
 // Get whether to use a verified deal or not.
 func parseVerified(cctx *cli.Context) bool {
 	return cctx.Bool(flagVerified.Name)
+}
+
+// Get whether to ask SP to remove unsealed copy.
+func parseRemoveUnsealed(cctx *cli.Context) bool {
+	return cctx.Bool(removeUnsealed.Name)
 }
 
 // Get the destination file to write the output to, erroring if not a valid

--- a/filclient.go
+++ b/filclient.go
@@ -499,7 +499,7 @@ func ComputePrice(askPrice types.BigInt, size abi.PaddedPieceSize, duration abi.
 	return (*abi.TokenAmount)(&cost), nil
 }
 
-func (fc *FilClient) MakeDeal(ctx context.Context, miner address.Address, data cid.Cid, price types.BigInt, minSize abi.PaddedPieceSize, duration abi.ChainEpoch, verified bool) (*network.Proposal, error) {
+func (fc *FilClient) MakeDeal(ctx context.Context, miner address.Address, data cid.Cid, price types.BigInt, minSize abi.PaddedPieceSize, duration abi.ChainEpoch, verified bool, removeUnsealed bool) (*network.Proposal, error) {
 	ctx, span := Tracer.Start(ctx, "makeDeal", trace.WithAttributes(
 		attribute.Stringer("miner", miner),
 		attribute.Stringer("price", price),
@@ -587,7 +587,7 @@ func (fc *FilClient) MakeDeal(ctx context.Context, miner address.Address, data c
 			Root:         data,
 			RawBlockSize: dataSize,
 		},
-		FastRetrieval: true,
+		FastRetrieval: !removeUnsealed,
 	}, nil
 }
 

--- a/filclient_test.go
+++ b/filclient_test.go
@@ -145,7 +145,7 @@ func TestStorage(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		proposal, err := fc.MakeDeal(ctx, addr, obj.Cid(), ask.Ask.Ask.Price, 0, 2880*365, false)
+		proposal, err := fc.MakeDeal(ctx, addr, obj.Cid(), ask.Ask.Ask.Price, 0, 2880*365, false, false)
 		require.NoError(t, err)
 
 		fmt.Printf("Sending proposal\n")


### PR DESCRIPTION
Allow consumers of filclient to pass a removeUnsealed parameter into MakeDeal, which sets the corresponding flag in the deal proposal. 

This allows filclient users to communicate whether or not they want SPs to store an unsealed copy.

When used via cli, filclient will default to `removeUnsealed = false`, which is consistent with boost's default. When calling MakeDeal, a value must be provided explicitly.