### PR TITLE
feat: v120 proposal extended config with accessible transfer options

### DIFF
--- a/filclient.go
+++ b/filclient.go
@@ -680,7 +680,6 @@ func ProposalV120WithLibp2pTransfer(
 func ProposalV120WithTransfer(transfer smtypes.Transfer) ProposalV120Option {
 	return func(cfg *ProposalV120Config, netprop network.Proposal) error {
 		cfg.transfer = transfer
-
 		return nil
 	}
 }

--- a/filclient.go
+++ b/filclient.go
@@ -646,7 +646,6 @@ type ProposalV120Option func(*ProposalV120Config, network.Proposal) error
 func ProposalV120WithDealUUID(dealUUID uuid.UUID) ProposalV120Option {
 	return func(cfg *ProposalV120Config, netprop network.Proposal) error {
 		cfg.dealUUID = dealUUID
-
 		return nil
 	}
 }


### PR DESCRIPTION
this change allows for a v120 proposal's transfer parameters to be modified. at the same time, i have wrapped up these configuration points into a variadic option pattern for better accessibility.

i have not tested this directly, but it's intended to be used in [delta](https://github.com/application-research/delta) and we should be able to verify functionality there!

example usage:

```go
fc.SendProposalV120WithOptions(
  ctx,
  netprop,
  ProposalV120WithDealUUID(dealUUID),
  ProposalV120WithLibp2pTransfer(announce, authToken, dbid),
)
```

if no transfer-related option is passed, the announce parameters will be left empty. to pass custom raw transfer params, use option `ProposalV120WithTransfer(smtypes.Transfer)`